### PR TITLE
chore: update ci/cd configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     commit-message:
-      prefix: "feat: "
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      prefix: "chore: "
+    groups:
+      baseimages:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     commit-message:
       prefix: "chore(ci): "
-    open-pull-requests-limit: 10

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: radiorabe/actions/.github/workflows/schedule-trivy.yaml@v0.20.6
+  schedule-trivy:
+    uses: radiorabe/actions/.github/workflows/schedule-trivy.yaml@v0.20.7
     with:
       image-ref: 'ghcr.io/radiorabe/jq:latest'

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -7,7 +7,7 @@ on:
       - release/*
 
 jobs:
-  call-workflow:
-    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@v0.20.6
+  semantic-release:
+    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@v0.20.7
     secrets:
       RABE_ITREAKTION_GITHUB_TOKEN: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}


### PR DESCRIPTION
# Initialize or Update CI/CD Pipelines

## Initialize [go-semantic-release](https://go-semantic-release.xyz/).

Based on [radiorabe/actions: Semantic Release](https://github.com/radiorabe/actions#semantic-release).

Semantic Releases are done by [@it-reaktion](https://github.com/it-reaktion). Ensure that this repo has access to the org-level `RABE_ITREAKTION_GITHUB_TOKEN` secret before merging this.

## Initialize Scheduled GitHub Actions

Configure scheduled CI runs.

### Schedule

```
13 12 * * *
```

### Jobs
* [Trivy](https://trivy.dev) (via [radiorabe/actions](https://radiorabe.github.io/actions/#container-schedule))

## Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create regular update PRs.
